### PR TITLE
Add unit tests for DI container

### DIFF
--- a/DiContainer.Tests/DiBuilderTests.cs
+++ b/DiContainer.Tests/DiBuilderTests.cs
@@ -1,0 +1,100 @@
+using System.Reflection;
+using Xunit;
+
+namespace GignerEngine.DiContainer.Tests;
+
+public class DiBuilderTests
+{
+    private class Foo {}
+    private class Bar {}
+    private class FooFactory : IFactory<Foo>
+    {
+        public Foo Create() => new Foo();
+        object IFactory.Create() => Create();
+    }
+
+    [Fact]
+    public void Bind_DefaultsToAsSingle()
+    {
+        var builder = new DiBuilder();
+        var bind = builder.Bind<Foo>();
+
+        var asSingle = (bool)typeof(Bind).GetField("asSingle", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(bind)!;
+        Assert.True(asSingle);
+    }
+
+    [Fact]
+    public void AsMultiple_SetsAsSingleFalse()
+    {
+        var builder = new DiBuilder();
+        var bind = builder.Bind<Foo>().AsMultiple();
+
+        var asSingle = (bool)typeof(Bind).GetField("asSingle", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(bind)!;
+        Assert.False(asSingle);
+    }
+
+    [Fact]
+    public void EagerAndLazy_TogglesFlag()
+    {
+        var builder = new DiBuilder();
+        var bind = builder.Bind<Foo>().Eager();
+        var eager = (bool)typeof(Bind).GetField("eager", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(bind)!;
+        Assert.True(eager);
+
+        bind.Lazy();
+        eager = (bool)typeof(Bind).GetField("eager", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(bind)!;
+        Assert.False(eager);
+    }
+
+    [Fact]
+    public void From_SetsInstanceType()
+    {
+        var builder = new DiBuilder();
+        var bind = builder.Bind<Foo>().From<Bar>();
+
+        var instanceType = (Type)typeof(Bind).GetField("instanceType", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(bind)!;
+        Assert.Equal(typeof(Bar), instanceType);
+    }
+
+    [Fact]
+    public void FromInstance_UsesFactoryDelegate()
+    {
+        var builder = new DiBuilder();
+        var instance = new Foo();
+        var bind = builder.Bind<Foo>().FromInstance(instance);
+
+        var factoryDel = (Bind.FactoryDelegate)typeof(Bind).GetField("factoryDelegate", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(bind)!;
+        Assert.Same(instance, factoryDel());
+    }
+
+    [Fact]
+    public void FromFactory_SetsFactoryType()
+    {
+        var builder = new DiBuilder();
+        var bind = builder.Bind<Foo>().FromFactory<FooFactory>();
+
+        var factoryType = (Type)typeof(Bind).GetField("factory", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(bind)!;
+        Assert.Equal(typeof(FooFactory), factoryType);
+    }
+
+    [Fact]
+    public void AddTag_StoresTag()
+    {
+        var builder = new DiBuilder();
+        var bind = builder.Bind<Foo>().AddTag("tag1");
+
+        var tags = (ICollection<string>)typeof(Bind).GetField("tags", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(bind)!;
+        Assert.Contains("tag1", tags);
+    }
+
+    [Fact]
+    public void BindParameter_AddsParameter()
+    {
+        var builder = new DiBuilder();
+        builder.BindParameter("name", "value");
+
+        var parameters = (Dictionary<string, object>)typeof(DiBuilder).GetField("parameters", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(builder)!;
+        Assert.True(parameters.ContainsKey("name"));
+        Assert.Equal("value", parameters["name"]);
+    }
+}

--- a/DiContainer.Tests/DiContainer.Tests.csproj
+++ b/DiContainer.Tests/DiContainer.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DiContainer.csproj" />
+  </ItemGroup>
+</Project>

--- a/DiContainer.Tests/DiContainerTests.cs
+++ b/DiContainer.Tests/DiContainerTests.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace GignerEngine.DiContainer.Tests
+{
+    public class DiContainerTests
+    {
+        private class Foo {}
+
+        private class Bar
+        {
+            public Foo Foo { get; }
+            public Bar(Foo foo)
+            {
+                Foo = foo;
+            }
+        }
+
+        private interface IService{}
+        private class Service1 : IService{}
+        private class Service2 : IService{}
+
+        private class ParameterClass
+        {
+            public string Name { get; }
+            public ParameterClass(string name)
+            {
+                Name = name;
+            }
+        }
+
+        private class FooFactory : IFactory<Foo>
+        {
+            public Foo Create() => new Foo();
+            object IFactory.Create() => Create();
+        }
+
+        private static DiContainer CreateContainer(IEnumerable<Bind> binds, Dictionary<string, object>? parameters = null)
+        {
+            var container = new DiContainer();
+            var defs = new Dictionary<System.Type, Definition>();
+            foreach (var bind in binds)
+            {
+                defs.Add(bind.type, new Definition { bind = bind });
+            }
+            typeof(DiContainer).GetField("_definitions", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(container, defs);
+            typeof(DiContainer).GetField("_parameters", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(container, parameters ?? new());
+            container.Init();
+            return container;
+        }
+
+        [Fact]
+        public void Resolve_ReturnsSameInstance_WhenAsSingle()
+        {
+            var container = CreateContainer(new[] { new Bind<Foo>().AsSingle() });
+
+            var foo1 = container.Resolve<Foo>();
+            var foo2 = container.Resolve<Foo>();
+
+            Assert.Same(foo1, foo2);
+        }
+
+        [Fact]
+        public void Resolve_ReturnsDifferentInstances_WhenAsMultiple()
+        {
+            var container = CreateContainer(new[] { new Bind<Foo>().AsMultiple() });
+
+            var foo1 = container.Resolve<Foo>();
+            var foo2 = container.Resolve<Foo>();
+
+            Assert.NotSame(foo1, foo2);
+        }
+
+        [Fact]
+        public void Resolve_InjectsDependencies()
+        {
+            var binds = new Bind[] { new Bind<Foo>(), new Bind<Bar>() };
+            var container = CreateContainer(binds);
+
+            var bar = container.Resolve<Bar>();
+
+            Assert.NotNull(bar.Foo);
+        }
+
+        [Fact]
+        public void Resolve_IncludesAllImplementations_WhenUsingResolveAll()
+        {
+            var binds = new Bind[]
+            {
+                new Bind<IService>().From<Service1>().AsMultiple(),
+                new Bind<IService>().From<Service2>().AsMultiple()
+            };
+            var container = CreateContainer(binds);
+
+            var services = container.ResolveAll<IService>();
+
+            Assert.Contains(services, s => s is Service1);
+            Assert.Contains(services, s => s is Service2);
+        }
+
+        [Fact]
+        public void Resolve_PassesParameters()
+        {
+            var parameters = new Dictionary<string, object> { { "name", "test" } };
+            var container = CreateContainer(new[] { new Bind<ParameterClass>() }, parameters);
+
+            var obj = container.Resolve<ParameterClass>();
+
+            Assert.Equal("test", obj.Name);
+        }
+
+        [Fact]
+        public void Resolve_UsingFactory()
+        {
+            var binds = new[] { new Bind<Foo>().FromFactory<FooFactory>() };
+            var container = CreateContainer(binds);
+
+            var foo = container.Resolve<Foo>();
+
+            Assert.NotNull(foo);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add xUnit test project
- test basic DI features like singletons, multiple instances, dependency injection, parameter injection, factories and resolve all
- refactor container tests to configure definitions directly instead of using `DiBuilder`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684010db78b08327a6a85abba2245fe7